### PR TITLE
Add missing snapshot dependencies to the generated docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,15 @@ USER root
 COPY build/libs/arc-spring-init-1.0.0.jar /deployments/app.jar
 WORKDIR /deployments
 RUN java -Djarmode=layertools -jar app.jar extract
+# Ensure that the snapshot-dependencies folder is created even if there were no snapshot dependencies in the jar file (to avoid error when copying from that directory below)
+RUN mkdir -p snapshot-dependencies
 
 ## Stage 2 : create image
 FROM amazoncorretto:21
 USER 185
 WORKDIR /deployments
 COPY --from=builder /deployments/dependencies/ ./
+COPY --from=builder /deployments/snapshot-dependencies/ ./
 COPY --from=builder /deployments/spring-boot-loader/ ./
 COPY --from=builder /deployments/application/ ./
 COPY config ./config


### PR DESCRIPTION
Spring Boot's extract tool that the Dockerfiles use to extract files from the spring boot jar file handles snapshot and non-snapshot dependencies differently - which currently causes the snapshot dependencies to be missing from the created docker image. With this commit, the snapshot dependencies are also added to the created docker image.

See also https://github.com/eclipse-lmos/lmos-sample-agents/pull/33